### PR TITLE
added ellipses to getMethylationStats

### DIFF
--- a/R/backbone.R
+++ b/R/backbone.R
@@ -905,7 +905,7 @@ setMethod("getMethylationStats", "methylRaw",
                           
                           par(mfrow=c(1,2))
                           if(labels){
-                            a=hist((plus.met),plot=F)
+                            a=hist((plus.met),plot=F,...)
                             my.labs=as.character(round(100*a$counts/length(plus.met),1))
                           }else{my.labs=FALSE}
                           hist((plus.met),col="cornflowerblue",
@@ -915,7 +915,7 @@ setMethod("getMethylationStats", "methylRaw",
                           mtext(object@sample.id, side = 3)
 
                           if(labels){                          
-                            a=hist((mnus.met),plot=F)
+                            a=hist((mnus.met),plot=F,...)
                             my.labs=as.character(round(100*a$counts/length(mnus.met),1))
                           }
                           else{my.labs=FALSE}
@@ -929,7 +929,7 @@ setMethod("getMethylationStats", "methylRaw",
                         }else{
                           if(labels){                          
                           
-                            a=hist((all.met),plot=F)
+                            a=hist((all.met),plot=F,...)
                             my.labs=as.character(round(100*a$counts/length(all.met),1))
                           }else{my.labs=FALSE}
                           hist((all.met),col="cornflowerblue",


### PR DESCRIPTION
I'm using methylKit 0.9.2, Rstudio 0.98.484, and R 3.0.2. Currently, if I try to override the default number of breaks for the histogram generated by getMethylationStats, it fails to pass the breaks argument on to the hist() function call that generates the labels. 

For example, if I try:

```
data(methylKit)
getMethylationStats(methylRawList.obj[[1]],plot=TRUE,both.strands=FALSE,labels=TRUE, breaks = 5)
getMethylationStats(methylRawList.obj[[1]],plot=TRUE,both.strands=FALSE,labels=TRUE, breaks = 20)
```

the images come out with incorrect labels because it's generating 10 labels instead of 5 or 20:

![breaks5](https://f.cloud.github.com/assets/944978/1872725/0c6ea1bc-78ab-11e3-93cd-3695b02d385a.png)
![breaks20](https://f.cloud.github.com/assets/944978/1872727/0fb21e62-78ab-11e3-9b45-6246ddee075f.png)

I fixed the problem by adding ellipses to the label-generating hist() function call.
