### PR TITLE
Fixes a bug in getMethylationStats() function 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: methylKit
 Type: Package
 Title: DNA methylation analysis from high-throughput
     bisulfite sequencing results
-Version: 0.9.2.0
+Version: 0.9.2.1
 Author: Altuna Akalin, Matthias Kormaksson, Sheng Li
 Maintainer: Altuna Akalin <aakalin@gmail.com>
 Description: methylKit is an R package for DNA methylation analysis and

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+methylKit 0.9.2.1
+--------------
+IMPROVEMENTS AND BUG FIXES
+
+* Fixes a bug in getMethylationStats() function that generates incorrect label numbers when the user overrides the default number 
+  of breaks for the histogram. Contributed by Bonnie Barrilleaux.
+
 methylKit 0.9.2
 --------------
 IMPROVEMENTS AND BUG FIXES

--- a/R/backbone.R
+++ b/R/backbone.R
@@ -905,7 +905,7 @@ setMethod("getMethylationStats", "methylRaw",
                           
                           par(mfrow=c(1,2))
                           if(labels){
-                            a=hist((plus.met),plot=F)
+                            a=hist((plus.met),plot=F,...)
                             my.labs=as.character(round(100*a$counts/length(plus.met),1))
                           }else{my.labs=FALSE}
                           hist((plus.met),col="cornflowerblue",
@@ -915,7 +915,7 @@ setMethod("getMethylationStats", "methylRaw",
                           mtext(object@sample.id, side = 3)
 
                           if(labels){                          
-                            a=hist((mnus.met),plot=F)
+                            a=hist((mnus.met),plot=F,...)
                             my.labs=as.character(round(100*a$counts/length(mnus.met),1))
                           }
                           else{my.labs=FALSE}
@@ -929,7 +929,7 @@ setMethod("getMethylationStats", "methylRaw",
                         }else{
                           if(labels){                          
                           
-                            a=hist((all.met),plot=F)
+                            a=hist((all.met),plot=F,...)
                             my.labs=as.character(round(100*a$counts/length(all.met),1))
                           }else{my.labs=FALSE}
                           hist((all.met),col="cornflowerblue",


### PR DESCRIPTION
Fixes a bug in getMethylationStats() function that generates incorrect label numbers when the user overrides the default number of breaks for the histogram. I fixed the problem by adding ellipses to the label-generating hist() function call, so that the breaks argument gets passed on.
