### PR TITLE
Add the vignette title to documentation indexing

### DIFF
--- a/vignettes/methylKit.Rmd
+++ b/vignettes/methylKit.Rmd
@@ -14,7 +14,7 @@ output:
       
 bibliography: Vignette_methylKit.bib
 vignette: >
-  %\VignetteIndexEntry{Vignette Title}
+  %\VignetteIndexEntry{methylKit: User Guide v`r packageVersion('methylKit')`}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
So far on the bioconductor webpage of the package http://www.bioconductor.org/packages/release/bioc/html/methylKit.html your vignette title is `Vignette Title` - this also can be seen in RStudio documentation viewer. This happens due to the extra knitr options of vignette.

![methylkit](https://cloud.githubusercontent.com/assets/6773454/19813619/dcf1aa44-9d3a-11e6-919b-3e59ffda6462.png)



You can read more about creating and understanding vignettes in Hadley's book - http://r-pkgs.had.co.nz/vignettes.html