### PR TITLE
Cirumvent OSX errors when reading gzipped files

### DIFF
--- a/R/backbone.R
+++ b/R/backbone.R
@@ -13,7 +13,7 @@ fread.gzipped<-function(filepath,...){
   if (R.utils::isGzipped(filepath)){
     
     if(.Platform$OS.type == "unix") {
-      filepath=paste("zcat",filepath)
+      filepath=paste("gunzip -c",filepath)
     } else {
       filepath <- R.utils::gunzip(filepath,temporary = FALSE, overwrite = TRUE,
                                   remove = FALSE)


### PR DESCRIPTION
- zcat on osx adds an ".Z" -extension prior to extraction
- internally zcat is a call of "gunzip -c"