### PR TITLE
Less NA tiles (suggested solution to issue #71)

### DIFF
--- a/R/regionalize.R
+++ b/R/regionalize.R
@@ -233,7 +233,7 @@ setMethod("regionCounts", signature(object="methylBase",regions="GRanges"),
             coverage=.SD=numTs=id=numTs1=covered=NULL
             
             # use data.table to sum up counts per region
-            sum.dt=dt[,c(lapply(.SD,sum),covered=length(numTs1)),by=id] 
+            sum.dt=dt[,c(lapply(.SD,sum, na.rm=T),covered=length(numTs1)),by=id] 
             sum.dt=sum.dt[sum.dt$covered>=cov.bases,]
             temp.df=as.data.frame(regions) # get regions to a dataframe
             
@@ -241,6 +241,10 @@ setMethod("regionCounts", signature(object="methylBase",regions="GRanges"),
             # valuesList = names(values(regions))
             # nameid = valuesList[grep (valuesList, pattern="name")]
             
+            #set all zero coverage tiles to missing
+            for ( j in seq(2,ncol(sum.dt),by=3) ){
+              data.table::set(sum.dt, which(sum.dt[[j]]==0),j:(j+2),NA)
+            }
 
 
             
@@ -461,7 +465,7 @@ setMethod("regionCounts", signature(object="methylBase",regions="GRangesList"),
             
             #set all zero coverage tiles to missing
             for ( j in seq(2,ncol(sum.dt),by=3) ){
-              set(sum.dt, which(sum.dt[[j]]==0),j:(j+2),NA)
+              data.table::set(sum.dt, which(sum.dt[[j]]==0),j:(j+2),NA)
             }
             
             #create a new methylBase object to return


### PR DESCRIPTION
These changes aims to treat missing values as a zero coverage site when tiling a methylBase object instead of setting the whole tile to be missing. 