### PR TITLE
quick fix for long filename issue

### DIFF
--- a/R/backbone.R
+++ b/R/backbone.R
@@ -1200,21 +1200,21 @@ setMethod("unite", "methylRawList",
     #print(names(as.list(match.call())))
     # catch additional args 
     args <- list(...)
-    #print(args)
+    # print(args)
     
     if( !( "dbdir" %in% names(args)) ){
       dbdir <- .check.dbdir(getwd())
     } else { dbdir <- .check.dbdir(args$dbdir) }
-    #                         if(!( "dbtype" %in% names(args) ) ){
-    #                           dbtype <- "tabix"
-    #                         } else { dbtype <- args$dbtype }
-#               if(!( "suffix" %in% names(args) ) ){
-#                 suffix <- paste0("_","base")
-#               } else { 
-#                 suffix <- args$suffix
-#                 suffix <- paste0("_",suffix)
-#               }
-    
+    if(!( "dbtype" %in% names(args) ) ){
+      dbtype <- "tabix"
+    } else { dbtype <- args$dbtype }
+    if(!( "suffix" %in% names(args) ) ){
+      suffix <- NULL
+    } else {
+      suffix <- args$suffix
+      suffix <- paste0("_",suffix)
+    }
+
     # create methylBaseDB
     #message(paste("creating file",paste0(methylObj@sample.id,suffix,".txt")))
     obj <- makeMethylBaseDB(df=df,dbpath=dbdir,dbtype="tabix",
@@ -1225,9 +1225,12 @@ setMethod("unite", "methylRawList",
                             coverage.index=coverage.ind,
                             numCs.index=numCs.ind,
                             numTs.index=numTs.ind,destranded=destrand,
-                            resolution=object[[1]]@resolution)#,
-                            #suffix=suffix)
+                            resolution=object[[1]]@resolution,
+                            suffix=suffix)
     obj@sample.ids <- sample.ids
+    
+    message(paste0("flatfile located at: ",obj@dbpath))
+    
     obj
 }
 }

--- a/R/diffMeth.R
+++ b/R/diffMeth.R
@@ -800,18 +800,22 @@ setMethod("calculateDiffMeth", "methylBase",
         #                           dbtype <- "tabix"
         #                         } else { dbtype <- args$dbtype }
         if(!( "suffix" %in% names(args) ) ){
-          suffix <- "_diffMeth"
+          suffix <- NULL
         } else { 
           suffix <- paste0("_",args$suffix)
         }
         
         # create methylDiffDB
-        makeMethylDiffDB(df=x,dbpath=dbdir,dbtype="tabix",
+        obj <- makeMethylDiffDB(df=x,dbpath=dbdir,dbtype="tabix",
                          sample.ids=.Object@sample.ids,
                          assembly=.Object@assembly,context=.Object@context,
                          destranded=.Object@destranded,
                          treatment=.Object@treatment,
                          resolution=.Object@resolution,suffix=suffix )
+        
+        message(paste0("flatfile located at: ",obj@dbpath))
+        
+        obj
       }
   
   }

--- a/R/methylDBClasses.R
+++ b/R/methylDBClasses.R
@@ -426,10 +426,15 @@ makeMethylBaseDB<-function(df,dbpath,dbtype,
                            suffix=NULL
                            )
   {
+  # new tabix file is named by "metyhlBase"+tmpstring, works for now
+  # if additional suffix is passed, tmpstring is skipped 
+  filepath <- paste0(ifelse(is.null(suffix),
+                            yes = tempfile(pattern = "methylBase",tmpdir = dbpath),
+                            no = paste0(dbpath,"/methylBase",suffix)),
+                     ".txt")
   
   # new tabix file is named by concatenation of sample.ids, works for now
-  # additional suffix is possible
-  filepath=paste0(dbpath,"/",paste0(sample.ids,collapse = "_"),suffix,".txt") 
+  # filepath=paste0(dbpath,"/",paste0(sample.ids,collapse = "_"),suffix,".txt") 
   #print(filepath)
   df <- df[with(df,order(chr,start,end)),]
   df2tabix(df,filepath)
@@ -579,8 +584,15 @@ makeMethylDiffDB<-function(df,dbpath,dbtype,
                            resolution,treatment,destranded,
                            suffix=NULL){
   
-  # new tabix file is named by concatenation of sample.ids, works for now
-  filepath=paste0(dbpath,"/",paste0(sample.ids,collapse = "_"),suffix,".txt")
+  # new tabix file is named by "metyhlBase"+tmpstring, works for now
+  # if additional suffix is passed, tmpstring is skipped 
+  filepath <- paste0(ifelse(is.null(suffix),
+                            yes = tempfile(pattern = "methylDiff",tmpdir = dbpath),
+                            no = paste0(dbpath,"/methylDiff",suffix)),
+                     ".txt")
+  
+  # # new tabix file is named by concatenation of sample.ids, works for now
+  # filepath=paste0(dbpath,"/",paste0(sample.ids,collapse = "_"),suffix,".txt")
   df <- df[with(df,order(chr,start,end)),]
   df2tabix(df,filepath)
   num.records=Rsamtools::countTabix(paste0(filepath,".bgz"))[[1]] ## 

--- a/R/methylDBFunctions.R
+++ b/R/methylDBFunctions.R
@@ -629,8 +629,23 @@ if(save.db) {
   } else {
     dir <- dirname(object[[1]]@dbpath)
   }
+  # if(!( "dbtype" %in% names(args) ) ){
+  #   dbtype <- "tabix"
+  # } else { dbtype <- args$dbtype }
+  if(!( "suffix" %in% names(args) ) ){
+    suffix <- NULL
+  } else {
+    suffix <- args$suffix
+    suffix <- paste0("_",suffix)
+  }
   
-  filename <- paste0(paste(getSampleID(object),collapse = "_"),".txt")
+  filename <- paste0( ifelse(is.null(suffix),
+                             yes = tempfile(pattern = "methylBase",tmpdir = "."),
+                             no = paste0("methylBase",suffix)),
+                      ".txt")
+
+  # filename <- tempfile(pattern = "methylBase",tmpdir = ".",fileext = ".txt")
+  #filename <- paste0(paste(getSampleID(object),collapse = "_"),".txt")
   
   if(is.null(min.per.group)) {
     
@@ -673,10 +688,15 @@ if(save.db) {
     
     unlink(list.files(dirname(tmpPath),pattern = basename(gsub(".txt.bgz","",tmpPath)),full.names = TRUE))
   }
-  readMethylBaseDB(dbpath = dbpath,dbtype = object[[1]]@dbtype,
+  obj <- readMethylBaseDB(dbpath = dbpath,dbtype = object[[1]]@dbtype,
                    sample.ids = getSampleID(object),assembly = object[[1]]@assembly,
                    context = object[[1]]@context,resolution = object[[1]]@resolution,
                    treatment = object@treatment,destranded = destrand)
+  
+  message(paste0("flatfile located at: ",obj@dbpath))
+  
+  obj
+  
 } else {
   obj <- object
   class(obj) <- "methylRawList"
@@ -876,8 +896,8 @@ setMethod("reconstruct",signature(mBase="methylBaseDB"),
       suffix <- paste0("_",args$suffix)
     }
     
-    filename <- paste0(paste(mBase@sample.ids,collapse = "_"),suffix,".txt")
-    #filename <- paste0(basename(gsub(".txt.bgz","",mBase@dbpath)),suffix,".txt")
+    # filename <- paste0(paste(mBase@sample.ids,collapse = "_"),suffix,".txt")
+    filename <- paste0(basename(gsub(".txt.bgz","",mBase@dbpath)),suffix,".txt")
     
     con <- file(methMat,open = "r") 
     
@@ -1130,13 +1150,14 @@ setMethod("reorganize", signature(methylObj="methylBaseDB"),
     } else { dir <- dirname(methylObj@dbpath) }
     
     if(!( "suffix" %in% names(args) ) ){
-      suffix <- NULL
+      suffix <- "_reorganized"
     } else { 
       suffix <- paste0("_",args$suffix)
     }
     
-    filename <- paste0(paste(sample.ids,collapse = "_"),suffix,".txt")
-    # filename <- paste0(basename(gsub(".txt.bgz",replacement = "",methylObj@dbpath)),suffix,".txt")
+    # filename <- paste0(paste(sample.ids,collapse = "_"),suffix,".txt")
+    filename <- paste0(basename(gsub(".txt.bgz","",methylObj@dbpath))
+                       ,suffix,".txt")
     
     newdbpath <- applyTbxByChunk(tbxFile = methylObj@dbpath,
                                  chunk.size = chunk.size, dir=dir,
@@ -1201,12 +1222,15 @@ setMethod("pool", "methylBaseDB",
         dir <- .check.dbdir(args$dbdir) }
     } else { dir <- dirname(obj@dbpath) }
     if(!( "suffix" %in% names(args) ) ){
-      suffix <- NULL
+      suffix <- "_pooled"
     } else { 
       suffix <- paste0("_",args$suffix)
     }
     
-    filename <- paste0(paste(sample.ids,collapse = "_"),suffix,".txt")
+    # filename <- paste0(paste(sample.ids,collapse = "_"),suffix,".txt")
+    
+    filename <- paste0(basename(gsub(".txt.bgz","",obj@dbpath))
+                       ,suffix,".txt")
     
     newdbpath <- applyTbxByChunk(tbxFile = obj@dbpath,chunk.size = chunk.size,
                                  dir=dir,filename = filename, 
@@ -1296,14 +1320,17 @@ setMethod("calculateDiffMeth", "methylBaseDB",
         }
       }
       if(!( "suffix" %in% names(args) ) ){
-        suffix <- "_diffMeth"
+        suffix <- NULL
       } else { 
         suffix <- paste0("_",args$suffix)
       }
       
-      filename <- paste0(paste(.Object@sample.ids,collapse = "_"),suffix,".txt")
+      # filename <- paste0(paste(.Object@sample.ids,collapse = "_"),suffix,".txt")
       
-      #filename <- paste(basename(gsub(".txt.bgz","",.Object@dbpath)),suffix,".txt")
+      filename <- paste0(basename( gsub("methylBase","methylDiff",
+                                       gsub(".txt.bgz","",.Object@dbpath)
+                                       ))
+                        ,suffix,".txt")
       
       dbpath <- applyTbxByChunk(.Object@dbpath,dir = 
                                   dir,chunk.size = chunk.size,  
@@ -1323,6 +1350,9 @@ setMethod("calculateDiffMeth", "methylBaseDB",
                            destranded=.Object@destranded,
                            treatment=.Object@treatment,
                            resolution=.Object@resolution)
+      
+      message(paste0("flatfile located at: ",obj@dbpath))
+      
       obj
       
     } else {
@@ -1547,12 +1577,13 @@ setMethod("regionCounts", signature(object="methylRawDB",regions="GRanges"),
       }
     } 
     if(!( "suffix" %in% names(args) ) ){
-      suffix <- paste0("_","regions")
+      suffix <- "_regions"
     } else { 
       suffix <- paste0("_",args$suffix)
     }
     
-    filename <- paste0(paste(object@sample.id,collapse = "_"),suffix,".txt")
+    filename <- paste0(basename(gsub(".txt.bgz","",object@dbpath))
+                       ,suffix,".txt")
     
     newdbpath <- applyTbxByOverlap(object@dbpath,chunk.size = chunk.size, 
                                    ranges=regions,  dir=dir,filename = filename, 
@@ -1642,13 +1673,16 @@ setMethod("regionCounts", signature(object="methylRawDB",regions="GRangesList"),
                 }
               } 
               if(!( "suffix" %in% names(args) ) ){
-                suffix <- paste0("_","regions")
+                suffix <- "_regions"
               } else { 
                 suffix <- paste0("_",args$suffix)
               }
               
               
-              filename <- paste0(paste(object@sample.id,collapse = "_"),suffix,".txt")
+              # filename <- paste0(paste(object@sample.id,collapse = "_"),suffix,".txt")
+              filename <- paste0(basename(gsub(".txt.bgz","",object@dbpath))
+                                 ,suffix,".txt")
+              
               
               newdbpath <- applyTbxByOverlap(object@dbpath,chunk.size = chunk.size, ranges=regions,  dir=dir,filename = filename, 
                                              return.type = "tabix", FUN = getCounts,regions,cov.bases,strand.aware)
@@ -1779,14 +1813,14 @@ setMethod("regionCounts", signature(object="methylBaseDB",regions="GRanges"),
         dir <- .check.dbdir(args$dbdir) 
       } 
       if(!( "suffix" %in% names(args) ) ){
-        suffix <- paste0("_","regions")
+        suffix <- "_regions"
       } else { 
         suffix <- paste0("_",args$suffix)
       }
       
-      filename <- paste0(paste(object@sample.ids,collapse = "_"),suffix,".txt")
+      # filename <- paste0(paste(object@sample.ids,collapse = "_"),suffix,".txt")
       
-      #filename <- paste(basename(gsub(".txt.bgz","",object@dbpath)),suffix,".txt")
+      filename <- paste(basename(gsub(".txt.bgz","",object@dbpath)),suffix,".txt")
       
       newdbpath <- applyTbxByOverlap(object@dbpath,chunk.size = chunk.size, 
                                      ranges=regions,  dir=dir,
@@ -1885,9 +1919,9 @@ setMethod("regionCounts", signature(object="methylBaseDB",regions="GRangesList")
                 suffix <- paste0("_",args$suffix)
               }
               
-              filename <- paste0(paste(object@sample.ids,collapse = "_"),suffix,".txt")
+              # filename <- paste0(paste(object@sample.ids,collapse = "_"),suffix,".txt")
               
-              #filename <- paste(basename(gsub(".txt.bgz","",object@dbpath)),suffix,".txt")
+              filename <- paste(basename(gsub(".txt.bgz","",object@dbpath)),suffix,".txt")
               
               newdbpath <- applyTbxByOverlap(object@dbpath,chunk.size = chunk.size, ranges=regions,  dir=dir,filename = filename, 
                                              return.type = "tabix", FUN = getCounts,regions,cov.bases,strand.aware)
@@ -1962,14 +1996,17 @@ setMethod("tileMethylCounts", signature(object="methylRawDB"),
                 }
               } 
               if(!( "suffix" %in% names(args) ) ){
-                suffix <- paste0("_","tiled")
+                suffix <- "_tiled"
               } else { 
                 suffix <- paste0("_",args$suffix)
               }
               
               
-              filename <- paste0(paste(object@sample.id,collapse = "_"),
-                                 suffix,".txt")
+              # filename <- paste0(paste(object@sample.id,collapse = "_"),
+              #                    suffix,".txt")
+              
+              filename <- paste(basename(gsub(".txt.bgz","",object@dbpath)),suffix,".txt")
+              
               
               newdbpath <- applyTbxByChr(object@dbpath, return.type = "tabix",
                                          dir = dir,filename = filename,
@@ -2080,7 +2117,10 @@ setMethod("tileMethylCounts", signature(object="methylBaseDB"),
       suffix <- paste0("_",args$suffix)
     }
     
-    filename <- paste0(paste(object@sample.ids,collapse = "_"),suffix,".txt")
+    # filename <- paste0(paste(object@sample.ids,collapse = "_"),suffix,".txt")
+    
+    filename <- paste(basename(gsub(".txt.bgz","",object@dbpath)),suffix,".txt")
+    
     
     newdbpath <- applyTbxByChr(object@dbpath, return.type = "tabix",
                                dir = dir,filename = filename,


### PR DESCRIPTION
I hope this works as a quick fix:

- methylrawdb files stay as they are, since they are not the problem
- methylbasedb and methydiffdb files: "methyBase/Diff" + random string or defined suffix


