### PR TITLE
Diffmeth dev

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: methylKit
 Type: Package
 Title: DNA methylation analysis from high-throughput
     bisulfite sequencing results
-Version: 1.3.2
+Version: 1.3.3
 Authors@R: c(person("Altuna", "Akalin", role = c("aut", "cre"),
   	     email = "aakalin@gmail.com"),
 	      person("Matthias","Kormaksson", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,14 @@
+methylKit 1.3.3
+--------------
+IMPROVEMENTS AND BUG FIXES
+* changes to calculateDiffMeth() function: add a message explaining 
+  the calculation procedure based on either two or more treatment groups, 
+  fixed bugs that prohibited the use of treatment groups other than 0/1 
+  in two group case, allow for more than two groups, update tests
+* changes in methSeg() function: update function documentation to 
+  inform that provided Granges has to be sorted, 
+  add check if granges is sorted and contains at least one meta.col
+
 methylKit 1.3.2
 --------------
 IMPROVEMENTS AND BUG FIXES

--- a/R/diffMeth.R
+++ b/R/diffMeth.R
@@ -713,18 +713,19 @@ setMethod("calculateDiffMeth", "methylBase",
       }
       
       if(length(unique(.Object@treatment))==2 ){
-        message("two groups detected: ",
-                "will do differential methylation calculation as difference of\n",
-                sprintf("treatment (group: %s) and control (group: %s)",
+        message("two groups detected:\n ",
+                "will calculate methylation difference as the difference of\n",
+                sprintf("treatment (group: %s) - control (group: %s)",
                         levels(as.factor(.Object@treatment))[2],
                         levels(as.factor(.Object@treatment))[1]))
       }
       
       if(length(unique(.Object@treatment))>2 ){
-        message("more than two groups detected: ",
-                "will do differential methylation calculation for a region\n",
-                "as difference of max(x) - min(x), ",
-                "with x being a vector of mean methylation per group.")
+        message("more than two groups detected:\n ",
+                "will calculate methylation difference as the difference ",
+                "of max(x) - min(x),\n ",
+                "where x is vector of mean methylation per group per region,",
+                "but \n the statistical test will remain the same.")
       }
       
       # add backwards compatibility with old parameters

--- a/R/diffMeth.R
+++ b/R/diffMeth.R
@@ -712,10 +712,19 @@ setMethod("calculateDiffMeth", "methylBase",
               "and control samples")
       }
       
+      if(length(unique(.Object@treatment))==2 ){
+        message("two groups detected: ",
+                "will do differential methylation calculation as difference of\n",
+                sprintf("treatment (group: %s) and control (group: %s)",
+                        levels(as.factor(.Object@treatment))[2],
+                        levels(as.factor(.Object@treatment))[1]))
+      }
+      
       if(length(unique(.Object@treatment))>2 ){
-        stop("can not do differential methylation calculation when there ",
-             "are more than\n
-             two groups, treatment vector indicates more than two groups")
+        message("more than two groups detected: ",
+                "will do differential methylation calculation for a region\n",
+                "as difference of max(x) - min(x), ",
+                "with x being a vector of mean methylation per group.")
       }
       
       # add backwards compatibility with old parameters

--- a/R/diffMeth.R
+++ b/R/diffMeth.R
@@ -789,7 +789,8 @@ setMethod("calculateDiffMeth", "methylBase",
         tmp <- as.data.frame(t(tmp))
         x=data.frame(subst[,1:4],tmp$p.value,
                      p.adjusted(tmp$q.value,method=adjust),
-                     meth.diff=tmp$meth.diff.1,stringsAsFactors=FALSE)
+                     meth.diff=tmp[,1],
+                     stringsAsFactors=FALSE)
         colnames(x)[5:7] <- c("pvalue","qvalue","meth.diff")
       }
       

--- a/R/methSeg.R
+++ b/R/methSeg.R
@@ -12,8 +12,8 @@
 #' @param obj \code{\link[GenomicRanges]{GRanges}}, \code{\link{methylDiff}}, 
 #' \code{\link{methylDiffDB}},
 #'            \code{\link{methylRaw}} or \code{\link{methylRawDB}} . If the object is a 
-#'            \code{\link[GenomicRanges]{GRanges}}
-#'             it should have one meta column with methylation scores
+#'            \code{\link[GenomicRanges]{GRanges}} it should have one meta column 
+#'            with methylation scores and has to be sorted 
 #' @param diagnostic.plot if TRUE a diagnostic plot is plotted. The plot shows
 #'        methylation and length statistics per segment group. In addition, it 
 #'        shows diagnostics from mixture modeling: the density function estimated 
@@ -85,6 +85,14 @@ methSeg<-function(obj, diagnostic.plot=TRUE, ...){
     stop("only methylRaw or methylDiff objects ", 
          "or GRanges objects can be used in this function")
   }
+  
+  ## check wether obj contains at least one metacol 
+  if(ncol(elementMetadata(obj))<1)
+    stop("GRanges does not have any meta column.")
+  
+  ## check wether obj contains is sorted
+  if(is.unsorted(obj))
+    stop("GRanges has to be sorted.")
   
   ## check wether obj contains at least two ranges else stop
   if(length(obj)<=1)

--- a/R/methSeg.R
+++ b/R/methSeg.R
@@ -75,7 +75,7 @@ methSeg<-function(obj, diagnostic.plot=TRUE, ...){
       obj= as(obj,"GRanges")
       ## calculate methylation score 
       mcols(obj)$meth=100*obj$numCs/obj$coverage
-      ## sort and destrand
+      ## sort 
       obj = sort(obj[,"meth"],ignore.strand=TRUE)
   }else if (class(obj)=="methylDiff" | class(obj)=="methylDiffDB") {
       obj = as(obj,"GRanges")
@@ -85,6 +85,9 @@ methSeg<-function(obj, diagnostic.plot=TRUE, ...){
     stop("only methylRaw or methylDiff objects ", 
          "or GRanges objects can be used in this function")
   }
+  
+  # destrand
+  strand(obj) <- "*"
   
   ## check wether obj contains at least one metacol 
   if(ncol(elementMetadata(obj))<1)

--- a/R/methylDBClasses.R
+++ b/R/methylDBClasses.R
@@ -587,7 +587,7 @@ makeMethylDiffDB<-function(df,dbpath,dbtype,
   # new tabix file is named by "metyhlBase"+tmpstring, works for now
   # if additional suffix is passed, tmpstring is skipped 
   filepath <- paste0(ifelse(is.null(suffix),
-                            yes = tempfile(pattern = "methylDiff",tmpdir = dbpath),
+                            yes = tempfile(pattern = "methylDiff_",tmpdir = dbpath),
                             no = paste0(dbpath,"/methylDiff",suffix)),
                      ".txt")
   

--- a/R/methylDBFunctions.R
+++ b/R/methylDBFunctions.R
@@ -1270,49 +1270,101 @@ setMethod("calculateDiffMeth", "methylBaseDB",
                    test=c("F","Chisq"),mc.cores=1,slim=TRUE,weighted.mean=TRUE,
                    chunk.size,save.db=TRUE,...){
             
-    if(length(.Object@treatment)<2 ){
-      stop("can not do differential methylation calculation with less than two samples")
-    }
-    if(length(unique(.Object@treatment))<2 ){
-      stop("can not do differential methylation calculation when there is no control\n
-           treatment option should have 0 and 1 designating treatment and control samples")
-    }
-    if(length(unique(.Object@treatment))>2 ){
-      stop("can not do differential methylation calculation when there are more than\n
-           two groups, treatment vector indicates more than two groups")
-    }
-    #### check if covariates+intercept+treatment more than replicates ####
-    if(!is.null(covariates)){if(ncol(covariates)+2 >= length(.Object@numTs.index))
-    {
-      stop("Too many covariates/too few replicates.")}
-    }
+      if(length(.Object@treatment)<2 ){
+        stop("can not do differential methylation calculation with less ",
+             "than two samples")
+      }
+      
+      if(length(unique(.Object@treatment))<2 ){
+        stop("can not do differential methylation calculation when there ",
+             "is no control\n",
+             "treatment option should have 0 and 1 designating treatment ",
+             "and control samples")
+      }
+      
+      if(length(unique(.Object@treatment))==2 ){
+        message("two groups detected:\n ",
+                "will calculate methylation difference as the difference of\n",
+                sprintf("treatment (group: %s) - control (group: %s)",
+                        levels(as.factor(.Object@treatment))[2],
+                        levels(as.factor(.Object@treatment))[1]))
+      }
+      
+      if(length(unique(.Object@treatment))>2 ){
+        message("more than two groups detected:\n ",
+                "will calculate methylation difference as the difference ",
+                "of max(x) - min(x),\n ",
+                "where x is vector of mean methylation per group per region,",
+                "but \n the statistical test will remain the same.")
+      }
+      
     
     if(save.db) {
-      
+
       # add backwards compatibility with old parameters
       if(slim==FALSE) adjust="BH" else adjust=adjust
       if(weighted.mean==FALSE) effect="mean" else effect=effect
       
       vars <- covariates
       
+      #### check if covariates+intercept+treatment more than replicates 
+      if(!is.null(covariates)){if(ncol(covariates)+2 >= length(.Object@numTs.index)){
+        stop("Too many covariates/too few replicates.")}}
+      
       # function to apply the test to data
-      diffMeth <- function(data,Ccols,Tcols,formula,vars,treatment,
+      diffMeth <- function(subst,Ccols,Tcols,formula,vars,treatment,
                            overdispersion,effect,
                            parShrinkMN,test,adjust,mc.cores){
         
-        cntlist=split(as.matrix(data[,c(Ccols,Tcols)]),1:nrow(data))
+        # get count matrix and make list
+        cntlist=split(as.matrix(subst[,c(Ccols,Tcols)]),1:nrow(subst))
         
-        tmp=simplify2array(
-          mclapply(cntlist,logReg,formula,vars,treatment=treatment,
-                   overdispersion=overdispersion,effect=effect,
-                   parShrinkMN=parShrinkMN,test=test,mc.cores=mc.cores))
-        tmp <- as.data.frame(t(tmp))
-        # print(head(data))
-        # print(head(tmp))
-        x=data.frame(data[,1:4],tmp$p.value,
-                     p.adjusted(tmp$q.value,method=adjust),
-                     meth.diff=tmp[,1],#$meth.diff.1,
-                     stringsAsFactors=FALSE)
+        if(length(treatment)==2 )
+        {
+          fpval=unlist( mclapply( cntlist,
+                                  function(x) fast.fisher(matrix(as.numeric( x) ,
+                                                                 ncol=2,byrow=F),
+                                                          conf.int = F)$p.value,
+                                  mc.cores=mc.cores,mc.preschedule = TRUE) ) 
+          
+          # set1 is the high, set2 is the low level of the group 
+          set1.Cs=Ccols[treatment==levels(as.factor(treatment))[2]]
+          set2.Cs=Ccols[treatment==levels(as.factor(treatment))[1]]
+          
+          # calculate mean methylation change
+          mom.meth1    = 100*(subst[,set1.Cs]/subst[,set1.Cs-1]) # get % methylation
+          mom.meth2    = 100*(subst[,set2.Cs]/subst[,set2.Cs-1])
+          # get difference between percent methylations
+          mom.mean.diff=mom.meth1-mom.meth2 
+          x=data.frame(subst[,1:4],fpval,
+                       p.adjusted(fpval,method=adjust),
+                       meth.diff=mom.mean.diff,stringsAsFactors=FALSE)
+          colnames(x)[5:7] <- c("pvalue","qvalue","meth.diff")
+          
+        }else{        
+          # call estimate shrinkage before logReg
+          if(overdispersion[1] == "shrinkMN"){
+            parShrinkMN<-estimateShrinkageMN(cntlist,
+                                             treatment=treatment,
+                                             covariates=vars,
+                                             sample.size=100000,
+                                             mc.cores=mc.cores)
+          }
+          
+          # get the result of tests
+          tmp=simplify2array(
+            mclapply(cntlist,logReg,formula,vars,treatment=treatment,
+                     overdispersion=overdispersion,effect=effect,
+                     parShrinkMN=parShrinkMN,test=test,mc.cores=mc.cores))
+          
+          # return the data frame part of methylDiff
+          tmp <- as.data.frame(t(tmp))
+          x=data.frame(subst[,1:4],tmp$p.value,
+                       p.adjusted(tmp$q.value,method=adjust),
+                       meth.diff=tmp[,1],
+                       stringsAsFactors=FALSE)
+          colnames(x)[5:7] <- c("pvalue","qvalue","meth.diff")
+        }
         
         return(x)
       }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -23,3 +23,13 @@ BEGIN_RCPP
     return R_NilValue;
 END_RCPP
 }
+
+static const R_CallMethodDef CallEntries[] = {
+    {"methylKit_methCall", (DL_FUNC) &methylKit_methCall, 9},
+    {NULL, NULL, 0}
+};
+
+RcppExport void R_init_methylKit(DllInfo *dll) {
+    R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
+    R_useDynamicSymbols(dll, FALSE);
+}

--- a/tests/testthat/test-4-calculateDiffMeth.r
+++ b/tests/testthat/test-4-calculateDiffMeth.r
@@ -18,19 +18,23 @@ mydblist = suppressMessages(methRead( file.list,
 methidh=unite(myobj)
 methidh2=unite(myobj,min.per.group=1L)
 methidh3=pool(methidh,sample.ids = c("test","control"))
+methidh4 <- methidh; getTreatment(methidh4) <- c(1,1,2,3)
 
 suppressMessages(methidhDB <- unite(mydblist))
 suppressMessages(methidh2DB <- unite(mydblist,min.per.group=1L))
 suppressMessages(methidh3DB <- pool(methidhDB,sample.ids = c("test","control")))
+suppressMessages(methidh4DB <- makeMethylDB(obj = methidh4,dbdir="methylDB"))
 
 # differential methylation
 myDiff =calculateDiffMeth(methidh)
 myDiff2=calculateDiffMeth(methidh2)
 myDiff3=calculateDiffMeth(methidh3)
+myDiff4=calculateDiffMeth(methidh4)
 
 suppressMessages(myDiffDB <- calculateDiffMeth(methidhDB))
 suppressMessages(myDiff2DB <- calculateDiffMeth(methidh2DB))
 suppressMessages(myDiff3DB <- calculateDiffMeth(methidh3DB))
+suppressMessages(myDiff4DB <- calculateDiffMeth(methidh4DB))
 
 hypo <- getMethylDiff(myDiff,difference=25,qvalue=0.01,type="hypo")
 hyper <- getMethylDiff(myDiff,difference=25,qvalue=0.01,type="hyper")
@@ -61,12 +65,32 @@ test_that("check if calculateDiffMeth output is a methylDiffDB object", {
 
 
 test_that("check if calculateDiffMeth output from unite(...,min.per.group=1) is a methylDiff object", {
-    expect_is(myDiff2, 'methylDiff')
+  expect_is(myDiff2, 'methylDiff')
 })
 
 test_that("check if calculateDiffMeth output from unite(...,min.per.group=1) is a methylDiffDB object", {
   expect_is(myDiff2DB, 'methylDiffDB')
 })
+
+
+test_that("check if calculateDiffMeth output from pooled methylBase is a methylDiff object", {
+    expect_is(myDiff3, 'methylDiff')
+})
+
+test_that("check if calculateDiffMeth output from pooled methylBaseDB is a methylDiffDB object", {
+  expect_is(myDiff3DB, 'methylDiffDB')
+})
+
+
+test_that("check if calculateDiffMeth output with three treatment groups is a methylDiff object", {
+  expect_is(myDiff4, 'methylDiff')
+})
+
+test_that("check if calculateDiffMeth output from three treatment groups is a methylDiffDB object", {
+  expect_is(myDiff4DB, 'methylDiffDB')
+})
+
+
 
 
 test_that("check getting hypo/hyper meth works with methylDiff", {


### PR DESCRIPTION
changes to calculateDiffMeth() function: 
- add a message explaining the calculation procedure based on either two or more treatment groups, 
- fixed bugs that prohibited the use of treatment groups other than 0/1 in two group case, 
- allow for more than two groups, 
- update tests

changes in methSeg() function: 
- update function documentation to inform that provided Granges has to be sorted, 
- add check if granges is sorted and contains at least one meta.col