### PR TITLE
Faster methSeg

### DIFF
--- a/R/methSeg.R
+++ b/R/methSeg.R
@@ -69,7 +69,8 @@
 #' 
 #' unlink(list.files(pattern="H1.chr21.chr22",full.names=TRUE))
 #' 
-#' @author Altuna Akalin, contributions by Arsene Waboand Katarzyna Wreczycka
+#' @author Altuna Akalin, contributions by Arsene Wabo and Katarzyna
+#' Wreczycka
 #' 
 #' @seealso \code{\link{methSeg2bed}}, \code{\link{joinSegmentNeighbours}} 
 #' 
@@ -149,7 +150,6 @@ methSeg<-function(obj, diagnostic.plot=TRUE, join.neighbours=FALSE,
     args.Mclust.esti[["score.gr"]]=seg.res[ sample(1:length(seg.res), nbr.sample) ]
     args.Mclust.esti[["diagnostic.plot"]]=FALSE
     dens_estimate=do.call("densityFind", args.Mclust.esti)
-<<<<<<< HEAD
     
     args.Mclust[["modelName"]] = dens_estimate$modelName
     args.Mclust[["G"]] = 1:dens_estimate$G
@@ -160,19 +160,6 @@ methSeg<-function(obj, diagnostic.plot=TRUE, join.neighbours=FALSE,
   args.Mclust[["score.gr"]]=seg.res
   args.Mclust[["diagnostic.plot"]]=diagnostic.plot
   dens=do.call("densityFind", args.Mclust  )
-=======
-
-    args.Mclust[["modelName"]] = dens_estimate$modelName
-    args.Mclust[["G"]] = 1:dens_estimate$G
-   }  
-  
-  if(!join.neighbours) {
-    # decide on number of components/groups
-    args.Mclust[["score.gr"]]=seg.res
-    args.Mclust[["diagnostic.plot"]]=diagnostic.plot
-    dens=do.call("densityFind", args.Mclust  )
-  }
->>>>>>> 7b26e193a53e45123d393e892effc41e2168da3d
   
   
   # add components/group ids 

--- a/man/methSeg.Rd
+++ b/man/methSeg.Rd
@@ -5,7 +5,8 @@
 \alias{methSeg}
 \title{Segment methylation or differential methylation profile}
 \usage{
-methSeg(obj, diagnostic.plot = TRUE, join.neighbours = FALSE, ...)
+methSeg(obj, diagnostic.plot = TRUE, join.neighbours = FALSE,
+  estimate.params.density = 1, ...)
 }
 \arguments{
 \item{obj}{\code{\link[GenomicRanges]{GRanges}}, \code{\link{methylDiff}}, 
@@ -24,6 +25,14 @@ in mixture modeling.}
 \item{join.neighbours}{if TRUE neighbouring segments that cluster to the same 
 seg.group are joined by extending the ranges, summing up num.marks and
 averaging over seg.means.}
+
+\item{estimate.params.density}{a numeric value indicating percentage of regions
+to sample and then estimate initial parameters (G and modelName) for a
+function to calculate density (\code{\link[mclust]{densityMclust}}). 
+The value can be between 0 and 1, e.g. 0.1 means that 10% of data will 
+be used for sampling, otherwise it uses the whole dataset (Default: 1) 
+and it's time consuming on large datasets. If 0 or 1 then the function 
+will be executed without sampling.}
 
 \item{...}{arguments to \code{\link[fastseg]{fastseg}} function in fastseg 
 package, or to \code{\link[mclust]{densityMclust}}

--- a/man/methSeg.Rd
+++ b/man/methSeg.Rd
@@ -87,5 +87,6 @@ unlink(list.files(pattern="H1.chr21.chr22",full.names=TRUE))
 \code{\link{methSeg2bed}}, \code{\link{joinSegmentNeighbours}}
 }
 \author{
-Altuna Akalin, contributions by Arsene Wabo
+Altuna Akalin, contributions by Arsene Wabo and Katarzyna
+Wreczycka
 }


### PR DESCRIPTION
Hi, 

Here I added an argument `estimate.params.density` to methSeg function to speed it up by first sampling data and to estimate on it parameters for mclust::densityMclust() (parameters: G=number of segment classes an modelName = name of a model used e.g. "V" is a variable variance (one-dimensional) ) and then run it on whole dataset. `estimate.params.density` indicates a percentage of data to sample.
Maybe you can find it useful

Kasia