### PR TITLE
Fastermeth seg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,14 +2,15 @@ Package: methylKit
 Type: Package
 Title: DNA methylation analysis from high-throughput
     bisulfite sequencing results
-Version: 1.7.4
+Version: 1.7.5
 Authors@R: c(person("Altuna", "Akalin", role = c("aut", "cre"),
                     email = "aakalin@gmail.com"),
 	           person("Matthias","Kormaksson", role = "aut"),
 	           person("Sheng","Li", role = "aut"),
 	           person("Arsene", "Wabo", role = "ctb"),
 	           person("Adrian", "Bierling", role= "aut"),
-	           person("Alexander","Gosdschan", role="aut"))
+	           person("Alexander","Gosdschan", role="aut"),
+	           person("Katarzyna","Wreczycka", role="ctb"))
 Author: Altuna Akalin [aut, cre], Matthias Kormaksson [aut], 
     Sheng Li [aut], Arsene Wabo [ctb], Adrian Bierling [aut], 
     Alexander Gosdschan [aut]

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,15 @@
+methylKit 1.7.5
+--------------
+NEW FUNCTIONS AND FEATURES
+* methSeg(): introduce parameter `initialize.on.subset` to subset data
+  for initialization of mixture modeling; update description; add tests
+
+
 methylKit 1.7.4
 --------------
 IMPROVEMENTS AND BUG FIXES
 * update link to test-file for methSeg() function
+
 
 methylKit 1.7.3
 --------------

--- a/R/methSeg.R
+++ b/R/methSeg.R
@@ -69,7 +69,8 @@
 #' 
 #' unlink(list.files(pattern="H1.chr21.chr22",full.names=TRUE))
 #' 
-#' @author Altuna Akalin, contributions by Arsene Wabo
+#' @author Altuna Akalin, contributions by Arsene Wabo and Katarzyna
+#' Wreczycka
 #' 
 #' @seealso \code{\link{methSeg2bed}}, \code{\link{joinSegmentNeighbours}} 
 #' 

--- a/R/methSeg.R
+++ b/R/methSeg.R
@@ -49,6 +49,16 @@
 #' @details      
 #'        To be sure that the algorithm will work on your data, 
 #'        the object should have at least 5000 records
+#'        
+#' @details After initial segmentation with fastseg(), segments are clustered 
+#'        into self-similar groups based on their mean methylation profile 
+#'        using mixture modeling. Mixture modeling estimates the initial 
+#'        parameters of the distributions by using the whole dataset. 
+#'        If "initialize.on.subset" argument set as described, the function 
+#'        will use a subset of the data to initialize the parameters of the 
+#'        mixture modeling prior to the Expectation-maximization (EM) algorithm 
+#'        used by \code{\link{Mclust}} package.
+#'  
 #' @examples 
 #' 
 #' \donttest{

--- a/R/methSeg.R
+++ b/R/methSeg.R
@@ -167,7 +167,6 @@ methSeg<-function(obj, diagnostic.plot=TRUE, join.neighbours=FALSE,
     message(paste("initializing clustering with",nbr.sample,"out of",length(seg.res),"total segments."))
     # estimate parameters for mclust
     sub <- sample(1:length(seg.res), nbr.sample,replace = FALSE)
-    if(length(sub) < 9 ){stop("too few samples, increase the size of subset.") }
     args.Mclust[["initialization"]]=list(subset = sub)
   }  
   

--- a/R/methSeg.R
+++ b/R/methSeg.R
@@ -52,7 +52,7 @@
 #' @examples 
 #' 
 #' \donttest{
-#'  download.file("https://github.com/BIMSBbioinfo/compgen2018/raw/master/day3_diffMeth/data/H1.chr21.chr22.rds",
+#'  download.file("https://dl.dropboxusercontent.com/u/1373164/H1.chr21.chr22.rds",
 #'                destfile="H1.chr21.chr22.rds",method="curl")
 #' 
 #'  mbw=readRDS("H1.chr21.chr22.rds")
@@ -69,7 +69,7 @@
 #' 
 #' unlink(list.files(pattern="H1.chr21.chr22",full.names=TRUE))
 #' 
-#' @author Altuna Akalin, contributions by Arsene Waboand Katarzyna Wreczycka
+#' @author Altuna Akalin, contributions by Arsene Wabo
 #' 
 #' @seealso \code{\link{methSeg2bed}}, \code{\link{joinSegmentNeighbours}} 
 #' 
@@ -84,15 +84,15 @@ methSeg<-function(obj, diagnostic.plot=TRUE, join.neighbours=FALSE,
   
   ##coerce object to granges
   if(class(obj)=="methylRaw" | class(obj)=="methylRawDB") {
-      obj= as(obj,"GRanges")
-      ## calculate methylation score 
-      mcols(obj)$meth=100*obj$numCs/obj$coverage
-      ## select only required mcol
-      obj = obj[,"meth"]
+    obj= as(obj,"GRanges")
+    ## calculate methylation score 
+    mcols(obj)$meth=100*obj$numCs/obj$coverage
+    ## select only required mcol
+    obj = obj[,"meth"]
   }else if (class(obj)=="methylDiff" | class(obj)=="methylDiffDB") {
-      obj = as(obj,"GRanges")
-      ## use methylation difference as score
-      obj = obj[,"meth.diff"]
+    obj = as(obj,"GRanges")
+    ## use methylation difference as score
+    obj = obj[,"meth.diff"]
   }else if (class(obj) != "GRanges"){
     stop("only methylRaw or methylDiff objects ", 
          "or GRanges objects can be used in this function")
@@ -149,34 +149,34 @@ methSeg<-function(obj, diagnostic.plot=TRUE, join.neighbours=FALSE,
     args.Mclust.esti[["score.gr"]]=seg.res[ sample(1:length(seg.res), nbr.sample) ]
     args.Mclust.esti[["diagnostic.plot"]]=FALSE
     dens_estimate=do.call("densityFind", args.Mclust.esti)
-
+    
     args.Mclust[["modelName"]] = dens_estimate$modelName
     args.Mclust[["G"]] = 1:dens_estimate$G
-   }  
+  }  
   
-  if(!join.neighbours) {
-    # decide on number of components/groups
-    args.Mclust[["score.gr"]]=seg.res
-    args.Mclust[["diagnostic.plot"]]=diagnostic.plot
-    dens=do.call("densityFind", args.Mclust  )
-  }
+  
+  # decide on number of components/groups
+  args.Mclust[["score.gr"]]=seg.res
+  args.Mclust[["diagnostic.plot"]]=diagnostic.plot
+  dens=do.call("densityFind", args.Mclust  )
+  
   
   # add components/group ids 
   mcols(seg.res)$seg.group=as.character(dens$classification)
   
   # if joining, show clustering after joining
   if(join.neighbours) {
-      message("joining neighbouring segments and repeating clustering.")
-      seg.res <- joinSegmentNeighbours(seg.res)
-      diagnostic.plot <- diagnostic.plot.old
-      
-      # get the new density
-      args.Mclust[["score.gr"]]=seg.res
-      args.Mclust[["diagnostic.plot"]]=diagnostic.plot
-      # skip second progress bar
-      args.Mclust[["verbose"]]=FALSE
-      dens=do.call("densityFind", args.Mclust  )
-      
+    message("joining neighbouring segments and repeating clustering.")
+    seg.res <- joinSegmentNeighbours(seg.res)
+    diagnostic.plot <- diagnostic.plot.old
+    
+    # get the new density
+    args.Mclust[["score.gr"]]=seg.res
+    args.Mclust[["diagnostic.plot"]]=diagnostic.plot
+    # skip second progress bar
+    args.Mclust[["verbose"]]=FALSE
+    dens=do.call("densityFind", args.Mclust  )
+    
   }
   
   seg.res
@@ -255,9 +255,9 @@ diagPlot<-function(dens,score.gr){
 #' @docType methods
 #' @rdname methSeg2bed
 methSeg2bed<-function(segments,filename,
-trackLine="track name='meth segments' description='meth segments' itemRgb=On",
-colramp=colorRamp(c("gray","green", "darkgreen"))
-                        ){
+                      trackLine="track name='meth segments' description='meth segments' itemRgb=On",
+                      colramp=colorRamp(c("gray","green", "darkgreen"))
+){
   if(class(segments)!="GRanges"){
     stop("segments object has to be of class GRanges")
   }

--- a/man/methSeg.Rd
+++ b/man/methSeg.Rd
@@ -5,7 +5,8 @@
 \alias{methSeg}
 \title{Segment methylation or differential methylation profile}
 \usage{
-methSeg(obj, diagnostic.plot = TRUE, join.neighbours = FALSE, ...)
+methSeg(obj, diagnostic.plot = TRUE, join.neighbours = FALSE,
+  estimate.params.density = 1, ...)
 }
 \arguments{
 \item{obj}{\code{\link[GenomicRanges]{GRanges}}, \code{\link{methylDiff}}, 
@@ -24,6 +25,14 @@ in mixture modeling.}
 \item{join.neighbours}{if TRUE neighbouring segments that cluster to the same 
 seg.group are joined by extending the ranges, summing up num.marks and
 averaging over seg.means.}
+
+\item{estimate.params.density}{a numeric value indicating percentage of regions
+to sample and then estimate initial parameters (G and modelName) for a
+function to calculate density (\code{\link[mclust]{densityMclust}}). 
+The value can be between 0 and 1, e.g. 0.1 means that 10% of data will 
+be used for sampling, otherwise it uses the whole dataset (Default: 1) 
+and it's time consuming on large datasets. If 0 or 1 then the function 
+will be executed without sampling.}
 
 \item{...}{arguments to \code{\link[fastseg]{fastseg}} function in fastseg 
 package, or to \code{\link[mclust]{densityMclust}}

--- a/man/methSeg.Rd
+++ b/man/methSeg.Rd
@@ -61,6 +61,15 @@ as high or low methylated regions.
 \details{
 To be sure that the algorithm will work on your data, 
        the object should have at least 5000 records
+
+After initial segmentation with fastseg(), segments are clustered 
+       into self-similar groups based on their mean methylation profile 
+       using mixture modeling. Mixture modeling estimates the initial 
+       parameters of the distributions by using the whole dataset. 
+       If "initialize.on.subset" argument set as described, the function 
+       will use a subset of the data to initialize the parameters of the 
+       mixture modeling prior to the Expectation-maximization (EM) algorithm 
+       used by \code{\link{Mclust}} package.
 }
 \examples{
 

--- a/man/methSeg.Rd
+++ b/man/methSeg.Rd
@@ -87,5 +87,6 @@ unlink(list.files(pattern="H1.chr21.chr22",full.names=TRUE))
 \code{\link{methSeg2bed}}, \code{\link{joinSegmentNeighbours}}
 }
 \author{
-Altuna Akalin, contributions by Arsene Wabo
+Altuna Akalin, contributions by Arsene Wabo and Katarzyna
+Wreczycka
 }

--- a/man/methSeg.Rd
+++ b/man/methSeg.Rd
@@ -6,7 +6,7 @@
 \title{Segment methylation or differential methylation profile}
 \usage{
 methSeg(obj, diagnostic.plot = TRUE, join.neighbours = FALSE,
-  estimate.params.density = 1, ...)
+  initialize.on.subset = 1, ...)
 }
 \arguments{
 \item{obj}{\code{\link[GenomicRanges]{GRanges}}, \code{\link{methylDiff}}, 
@@ -26,13 +26,13 @@ in mixture modeling.}
 seg.group are joined by extending the ranges, summing up num.marks and
 averaging over seg.means.}
 
-\item{estimate.params.density}{a numeric value indicating percentage of regions
-to sample and then estimate initial parameters (G and modelName) for a
-function to calculate density (\code{\link[mclust]{densityMclust}}). 
-The value can be between 0 and 1, e.g. 0.1 means that 10% of data will 
-be used for sampling, otherwise it uses the whole dataset (Default: 1) 
-and it's time consuming on large datasets. If 0 or 1 then the function 
-will be executed without sampling.}
+\item{initialize.on.subset}{a numeric value indicating either percentage or
+absolute value of regions to subsample from segments before performing
+the mixture modeling. The value can be either between 0 and 1, 
+e.g. 0.1 means that 10% of data will be used for sampling, or be an 
+integer higher than 1 to define the number of regions to sample. 
+By default uses the whole dataset, which can be time consuming on 
+large datasets. (Default: 1)}
 
 \item{...}{arguments to \code{\link[fastseg]{fastseg}} function in fastseg 
 package, or to \code{\link[mclust]{densityMclust}}

--- a/tests/testthat/test-8-methSeg.r
+++ b/tests/testthat/test-8-methSeg.r
@@ -55,6 +55,12 @@ test_that("check if joining neighbours works" ,{
   expect_true(all(rle(res2$seg.group)$lengths == 1))
 })
 
+test_that("check if initialization works" ,{
+  expect_is(methSeg(methylDiff.obj,diagnostic.plot = FALSE,verbose=FALSE),"GRanges")
+  expect_is(methSeg(methylDiff.obj,diagnostic.plot = FALSE,verbose=FALSE,initialization=list(subset = sample(1:13,9,replace = FALSE))),"GRanges")
+  expect_error(methSeg(methylDiff.obj,diagnostic.plot = FALSE,verbose=FALSE,initialize.on.subset = 0.6))
+  expect_is(methSeg(methylDiff.obj,diagnostic.plot = FALSE,verbose=FALSE,initialize.on.subset = 10),"GRanges")
+})
 
 seg <- methSeg(tileRaw,diagnostic.plot = FALSE)
 methSeg2bed(segments = seg, filename = "test.bed")


### PR DESCRIPTION
This pull request is based on the changes that @al2na requested for the subsetting.

> but these are extreme cases, also in your code you need to have seg.res somewhere, seg.res is created within methSeg() to be meaningful. I think you guys can use a new argument called "initialize.on.subset" can be a number between 0 and 1, or if larger than 1 it should be taken as number of samples, then just sample rows from output of fastseg() and use that in initialization=list(subset=...) . but please check what happens when the user also provides "initialization" argument, in that case we should not run our initialization but users argument should over-ride. This is really quite easy code.