### PR TITLE
add cores arg to methSeg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: methylKit
 Type: Package
 Title: DNA methylation analysis from high-throughput
     bisulfite sequencing results
-Version: 1.7.5
+Version: 1.7.6
 Authors@R: c(person("Altuna", "Akalin", role = c("aut", "cre"),
                     email = "aakalin@gmail.com"),
 	           person("Matthias","Kormaksson", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,10 @@
+methylKit 1.7.6
+--------------
+NEW FUNCTIONS AND FEATURES
+* methSeg(): introduce parameter `cores` to run fastseg in parallel
+  per chromosome; update description; add tests
+
+
 methylKit 1.7.5
 --------------
 NEW FUNCTIONS AND FEATURES

--- a/R/methSeg.R
+++ b/R/methSeg.R
@@ -1,5 +1,110 @@
 # segmentation functions 
 
+.run.fastseg = function(obj, ...){
+  
+  dots <- list(...)
+  
+  ## check wether obj contains at least one metacol 
+  if(ncol(elementMetadata(obj))<1)
+    stop("GRanges does not have any meta column.")
+  
+  ## check wether obj contains is sorted by position
+  if(is.unsorted(obj,ignore.strand=TRUE)) {
+    obj <- sort(obj,ignore.strand=TRUE)
+    message("Object not sorted by position, sorting now.")
+  }
+  
+  ## check wether obj contains at least two ranges else stop
+  if(length(obj)<=1)
+    stop("segmentation requires at least two ranges.")
+  
+  # match argument names to fastseg arguments
+  args.fastseg=dots[names(dots) %in% names(formals(fastseg)[-1] ) ]  
+  
+  args.fastseg[["x"]]=obj
+  
+  # do the segmentation
+  #seg.res=fastseg(obj)
+  seg.res <- do.call("fastseg", args.fastseg)
+  
+  # stop if segmentation produced only one range
+  if(length(seg.res)==1) {
+    warning("segmentation produced only one range, no mixture modeling possible.")
+    seg.res$seg.group <- "1"
+    return(seg.res)
+  }
+  return(seg.res)
+}
+
+
+.run.mclust = function(seg.res, diagnostic.plot=TRUE, join.neighbours=FALSE,
+                       initialize.on.subset=1, ...){
+  
+  dots <- list(...)
+  
+  # match argument names to Mclust
+  args.Mclust=dots[names(dots) %in% names(formals(Mclust)[-1])  ]
+  
+  # if joining, do not show first clustering
+  if(join.neighbours) {
+    diagnostic.plot.old = diagnostic.plot
+    diagnostic.plot = FALSE
+  }
+  
+  if("initialization" %in% names(args.Mclust)){
+    if("subset" %in% names(args.Mclust[["initialization"]])) {
+      if(length(args.Mclust[["initialization"]][["subset"]]) < 9 ){
+        stop("too few samples, increase the size of subset.") 
+      }
+      message(paste("initializing clustering with",
+                    length(args.Mclust[["initialization"]][["subset"]]),
+                    "segments."))
+      initialize.on.subset = 1
+    }
+  }
+  
+  if(initialize.on.subset != 1 && initialize.on.subset > 0 ) {
+    
+    if( initialize.on.subset > 0 & initialize.on.subset < 1 )
+      nbr.sample = floor(length(seg.res) * initialize.on.subset)
+    
+    if( initialize.on.subset > 1) 
+      nbr.sample = initialize.on.subset
+    
+    if( nbr.sample < 9 ){stop("too few samples, increase the size of subset.") }
+    
+    message(paste("initializing clustering with",nbr.sample,"out of",length(seg.res),"total segments."))
+    # estimate parameters for mclust
+    sub <- sample(1:length(seg.res), nbr.sample,replace = FALSE)
+    args.Mclust[["initialization"]]=list(subset = sub)
+  }  
+  
+  # decide on number of components/groups
+  args.Mclust[["score.gr"]]=seg.res
+  args.Mclust[["diagnostic.plot"]]=diagnostic.plot
+  dens=do.call("densityFind", args.Mclust  )
+  
+  # add components/group ids 
+  mcols(seg.res)$seg.group=as.character(dens$classification)
+  
+  # if joining, show clustering after joining
+  if(join.neighbours) {
+    message("joining neighbouring segments and repeating clustering.")
+    seg.res <- joinSegmentNeighbours(seg.res)
+    diagnostic.plot <- diagnostic.plot.old
+    
+    # get the new density
+    args.Mclust[["score.gr"]]=seg.res
+    args.Mclust[["diagnostic.plot"]]=diagnostic.plot
+    # skip second progress bar
+    args.Mclust[["verbose"]]=FALSE
+    dens=do.call("densityFind", args.Mclust  )
+    
+  }
+  return(seg.res)
+}
+
+
 #' Segment methylation or differential methylation profile
 #' 
 #' The function uses a segmentation algorithm (\code{\link[fastseg]{fastseg}}) 
@@ -30,6 +135,8 @@
 #'        integer higher than 1 to define the number of regions to sample. 
 #'        By default uses the whole dataset, which can be time consuming on 
 #'        large datasets. (Default: 1)
+#' @param cores number of cores. The function is parallelized per chromosome
+#'        (default: 1).
 #' @param ... arguments to \code{\link[fastseg]{fastseg}} function in fastseg 
 #'        package, or to \code{\link[mclust]{densityMclust}}
 #'        in Mclust package, could be used to fine tune the segmentation algorithm.
@@ -88,125 +195,118 @@
 #' @docType methods
 #' @rdname methSeg       
 methSeg<-function(obj, diagnostic.plot=TRUE, join.neighbours=FALSE,
-                  initialize.on.subset=1, ...){
+                  initialize.on.subset=1,
+                  cores=1, ...){
   
-  dots <- list(...)  
+  # 1. Run segmentation
   
-  
-  ##coerce object to granges
-  if(class(obj)=="methylRaw" | class(obj)=="methylRawDB") {
-    obj= as(obj,"GRanges")
-    ## calculate methylation score 
-    mcols(obj)$meth=100*obj$numCs/obj$coverage
-    ## select only required mcol
-    obj = obj[,"meth"]
-  }else if (class(obj)=="methylDiff" | class(obj)=="methylDiffDB") {
-    obj = as(obj,"GRanges")
-    ## use methylation difference as score
-    obj = obj[,"meth.diff"]
-  }else if (class(obj) != "GRanges"){
-    stop("only methylRaw or methylDiff objects ", 
-         "or GRanges objects can be used in this function")
+  if(cores==1){
+    
+    ##coerce object to granges
+    if(class(obj)=="methylRaw" | class(obj)=="methylRawDB") {
+      obj= as(obj,"GRanges")
+      ## calculate methylation score 
+      mcols(obj)$meth=100*obj$numCs/obj$coverage
+      ## select only required mcol
+      obj = obj[,"meth"]
+    }else if (class(obj)=="methylDiff" | class(obj)=="methylDiffDB") {
+      obj = as(obj,"GRanges")
+      ## use methylation difference as score
+      obj = obj[,"meth.diff"]
+    }else if (class(obj) != "GRanges"){
+      stop("only methylRaw or methylDiff objects ", 
+           "or GRanges objects can be used in this function")
+    }
+    
+    # destrand
+    strand(obj) <- "*"
+    
+    # Run segmentation
+    seg.res = .run.fastseg(obj)
   }
   
-  # destrand
-  strand(obj) <- "*"
-  
-  ## check wether obj contains at least one metacol 
-  if(ncol(elementMetadata(obj))<1)
-    stop("GRanges does not have any meta column.")
-  
-  ## check wether obj contains is sorted by position
-  if(is.unsorted(obj,ignore.strand=TRUE)) {
-    obj <- sort(obj,ignore.strand=TRUE)
-    message("Object not sorted by position, sorting now.")
-  }
-  
-  ## check wether obj contains at least two ranges else stop
-  if(length(obj)<=1)
-    stop("segmentation requires at least two ranges.")
-  
-  # match argument names to fastseg arguments
-  args.fastseg=dots[names(dots) %in% names(formals(fastseg)[-1] ) ]  
-  
-  # match argument names to Mclust
-  args.Mclust=dots[names(dots) %in% names(formals(Mclust)[-1])  ]
-  
-  args.fastseg[["x"]]=obj
-  
-  # do the segmentation
-  #seg.res=fastseg(obj)
-  seg.res <- do.call("fastseg", args.fastseg)
-  #seg.res <- do.call("fastseg2", args.fastseg)
-  
-  # stop if segmentation produced only one range
-  if(length(seg.res)==1) {
-    warning("segmentation produced only one range, no mixture modeling possible.")
-    seg.res$seg.group <- "1"
-    return(seg.res)
-  }
-  
-  # if joining, do not show first clustering
-  if(join.neighbours) {
-    diagnostic.plot.old = diagnostic.plot
-    diagnostic.plot = FALSE
-  }
-  
-  if("initialization" %in% names(args.Mclust)){
-    if("subset" %in% names(args.Mclust[["initialization"]])) {
-      if(length(args.Mclust[["initialization"]][["subset"]]) < 9 ){
-        stop("too few samples, increase the size of subset.") 
+  if(cores>1){
+    
+    ## Non-tabix files  
+    if (class(obj)=="methylDiff" | class(obj)=="methylRaw" | 
+        class(obj)=="GRanges"){
+      
+      ##coerce object to granges
+      if(class(obj)=="methylRaw") {
+        obj= as(obj,"GRanges")
+        ## calculate methylation score 
+        mcols(obj)$meth=100*obj$numCs/obj$coverage
+        ## select only required mcol
+        obj = obj[,"meth"]
+      } else if(class(obj)=="methylDiff") {
+        obj = as(obj,"GRanges")
+        ## use methylation difference as score
+        obj = obj[,"meth.diff"]
+      }else if (class(obj) != "GRanges"){
+        stop("only methylRaw or methylDiff objects ", 
+             "or GRanges objects can be used in this function")
+      }
+      # destrand
+      strand(obj) <- "*"
+      
+      chrs = seqlevels(obj)
+      # Split the input object based on chromosome
+      # run methSeg on chromosomes (Could be in parallel or not)
+      seg.res.list <- mclapply(chrs, function(chr){
+        seg.res = .run.fastseg(obj[seqnames(obj)==chr])
+      }, mc.cores=cores)
+      
+      # Merge resulting segments again to whole genome.
+      # suppressWarnings -> combined objs dont have chrs in common
+      seg.res = suppressWarnings( do.call("c", seg.res.list) )
+      
+      ## Tabix files
+    } else if(class(obj)=="methylDiffDB" | class(obj)=="methylRawDB"){
+      
+      .run.fastseg.tabix = function(gr0, ...){
+        
+        # adjust colnames of input GRanges to 
+        # methylKit naming convention
+        df2getcolnames = as.data.frame(gr0[1])
+        df2getcolnames$width = NULL 
+        methylKit:::.setMethylDBNames(df2getcolnames)
+        names(mcols(gr0)) = colnames(df2getcolnames)[5:ncol(df2getcolnames)]
+        
+        if("coverage" %in% names(mcols(gr0))){
+          gr0$meth = 100*gr0$numCs/gr0$coverage
+          gr0 = gr0[,"meth"]
+        }else if("meth.diff" %in% names(mcols(gr0))){
+          gr0 = gr0[,"meth.diff"]
+        }else if (class(obj) != "GRanges"){
+          stop("only methylRaw or methylDiff objects ", 
+               "or GRanges objects can be used in this function")
         }
-      message(paste("initializing clustering with",
-                    length(args.Mclust[["initialization"]][["subset"]]),
-                    "segments."))
-      initialize.on.subset = 1
+        # destrand
+        strand(gr0) <- "*"
+        
+        .run.fastseg(gr0, ...)
+      }
+      
+      seg.res <- applyTbxByChr(obj@dbpath,
+                               return.type = "GRanges",
+                               FUN = .run.fastseg.tabix,
+                               ...,
+                               mc.cores = cores)
     }
   }
   
-  if(initialize.on.subset != 1 && initialize.on.subset > 0 ) {
-    
-    if( initialize.on.subset > 0 & initialize.on.subset < 1 )
-      nbr.sample = floor(length(seg.res) * initialize.on.subset)
-    
-    if( initialize.on.subset > 1) 
-      nbr.sample = initialize.on.subset
-    
-    if( nbr.sample < 9 ){stop("too few samples, increase the size of subset.") }
-    
-    message(paste("initializing clustering with",nbr.sample,"out of",length(seg.res),"total segments."))
-    # estimate parameters for mclust
-    sub <- sample(1:length(seg.res), nbr.sample,replace = FALSE)
-    args.Mclust[["initialization"]]=list(subset = sub)
-  }  
+  # 2. Density Estimation via Model-Based Clustering
   
-  
-  # decide on number of components/groups
-  args.Mclust[["score.gr"]]=seg.res
-  args.Mclust[["diagnostic.plot"]]=diagnostic.plot
-  dens=do.call("densityFind", args.Mclust  )
-  
-  
-  # add components/group ids 
-  mcols(seg.res)$seg.group=as.character(dens$classification)
-  
-  # if joining, show clustering after joining
-  if(join.neighbours) {
-    message("joining neighbouring segments and repeating clustering.")
-    seg.res <- joinSegmentNeighbours(seg.res)
-    diagnostic.plot <- diagnostic.plot.old
-    
-    # get the new density
-    args.Mclust[["score.gr"]]=seg.res
-    args.Mclust[["diagnostic.plot"]]=diagnostic.plot
-    # skip second progress bar
-    args.Mclust[["verbose"]]=FALSE
-    dens=do.call("densityFind", args.Mclust  )
-    
+  if( length(seg.res) > 1 ){
+    seg.res = .run.mclust(seg.res,
+                          diagnostic.plot=diagnostic.plot, 
+                          join.neighbours=join.neighbours,
+                          initialize.on.subset=initialize.on.subset,
+                          cores=cores, ...)
   }
-  
-  seg.res
+  return(seg.res)
 }
+
 
 # not needed
 .methSeg<-function(score.gr,score.cols=NULL,...){

--- a/man/methSeg.Rd
+++ b/man/methSeg.Rd
@@ -6,7 +6,7 @@
 \title{Segment methylation or differential methylation profile}
 \usage{
 methSeg(obj, diagnostic.plot = TRUE, join.neighbours = FALSE,
-  initialize.on.subset = 1, ...)
+  initialize.on.subset = 1, cores = 1, ...)
 }
 \arguments{
 \item{obj}{\code{\link[GenomicRanges]{GRanges}}, \code{\link{methylDiff}}, 
@@ -33,6 +33,9 @@ e.g. 0.1 means that 10% of data will be used for sampling, or be an
 integer higher than 1 to define the number of regions to sample. 
 By default uses the whole dataset, which can be time consuming on 
 large datasets. (Default: 1)}
+
+\item{cores}{number of cores. The function is parallelized per chromosome
+(default: 1).}
 
 \item{...}{arguments to \code{\link[fastseg]{fastseg}} function in fastseg 
 package, or to \code{\link[mclust]{densityMclust}}
@@ -74,7 +77,7 @@ After initial segmentation with fastseg(), segments are clustered
 \examples{
 
 \donttest{
- download.file("https://github.com/BIMSBbioinfo/compgen2018/raw/master/day3_diffMeth/data/H1.chr21.chr22.rds",
+ download.file("https://dl.dropboxusercontent.com/u/1373164/H1.chr21.chr22.rds",
                destfile="H1.chr21.chr22.rds",method="curl")
 
  mbw=readRDS("H1.chr21.chr22.rds")

--- a/tests/testthat/test-8-methSeg.r
+++ b/tests/testthat/test-8-methSeg.r
@@ -25,6 +25,27 @@ test_that("check if methSeg returns error for methylBase objects" ,{
   expect_error(methSeg(methylBase.obj,diagnostic.plot = FALSE))
 })
 
+test_that("check if methSeg with cores > 1 is the same as cores=1" ,{
+  a=methSeg(methylRawList.obj[[3]],diagnostic.plot = FALSE)
+  b=methSeg(methylRawList.obj[[3]],diagnostic.plot = FALSE, cores=2)
+  expect_equal(a,b)
+})
+
+test_that("check if methSeg with cores > 1 is the same as cores=1 (non-tabix file)" ,{
+  a=methSeg(methylRawList.obj[[3]],diagnostic.plot = FALSE)
+  b=methSeg(methylRawList.obj[[3]],diagnostic.plot = FALSE, cores=2)
+  expect_equal(a,b)
+})
+
+methylRawDB.obj <- methRead(
+  system.file("extdata", "control1.myCpG.txt", package = "methylKit"),
+  sample.id = "ctrl1", assembly = "hg18")
+
+test_that("check if methSeg with cores > 1 is the same as cores=1 (tabix file)" ,{
+  a=methSeg(methylRawDB.obj,diagnostic.plot = FALSE)
+  b=methSeg(methylRawDB.obj,diagnostic.plot = FALSE, cores=2)
+  expect_equal(a,b)
+})
 
 gr = as(methylRawList.obj[[1]],"GRanges")
 mcols(gr)$meth=100*gr$numCs/gr$coverage


### PR DESCRIPTION
Hi guys,
I added parallel methSeg() with methylDB objects and non-tabix objects.
I separated code for running fastseg and mclust into two auxiliary function .run.fastseg and .run.mclust. Parallelization is in the step of fastseg and each fastseg run is concatenated. For that, I added to `return.type` in `applyTbxByChr` "GRanges" to concatenate GRanges.
I wrote some tests, but I think I maybe should add more of them
Let me know what do you think about it
Kasia