### PR TITLE
applyTbxByChunk:

### DIFF
--- a/R/percMethylation.R
+++ b/R/percMethylation.R
@@ -40,6 +40,7 @@ setMethod("percMethylation", "methylBase",
     meth.mat = 100 * x[, methylBase.obj@numCs.index]/(
       x[,methylBase.obj@numCs.index] + x[,methylBase.obj@numTs.index] )                                      
     names(meth.mat)=methylBase.obj@sample.ids
+    rownames(meth.mat) <- NULL
     if(rowids){
       rownames(meth.mat)=as.character(paste(x[,1],x[,2],x[,3],sep=".") )
     }

--- a/R/tabix.functions.R
+++ b/R/tabix.functions.R
@@ -636,7 +636,7 @@ tabix2gr<-function(tabixRes){
 #' @noRd
 applyTbxByChunk<-function(tbxFile,chunk.size=1e6,dir,filename,
                           return.type=c("tabix","data.frame","data.table","text"),
-                          FUN,...,tabixHead=NULL){
+                          FUN,...,tabixHead=NULL,textHeader=NULL){
   
   return.type <- match.arg(return.type)
   FUN <- match.fun(FUN)
@@ -711,6 +711,13 @@ applyTbxByChunk<-function(tbxFile,chunk.size=1e6,dir,filename,
       unlink(outfile)
     }
     con=file(outfile, open = "a", blocking = TRUE) # open connection  
+    # write header if provided
+    if(!is.null(textHeader)) 
+      write(file = con,
+            x = textHeader,
+            ncolumns = length(textHeader),
+            sep = "\t")
+    # append result files
     for(file in gtools::mixedsort(
       list.files(path = dir, pattern = filename2,full.names=TRUE))){
       file.append(outfile,file) # append files

--- a/tests/testthat/test-percMethylation.R
+++ b/tests/testthat/test-percMethylation.R
@@ -1,0 +1,43 @@
+context("test percMethylation function")
+
+data("methylKit")
+
+dbdir = "methylDB"
+methylBaseDB = makeMethylDB(methylBase.obj, dbdir = dbdir)
+
+## no save txt
+test_that("check if percMethylation is same for methylBase and methylBaseDB",
+          {
+            expect_equal(
+              percMethylation(methylBase.obj, save.txt = FALSE, rowids = TRUE),
+              percMethylation(methylBaseDB, save.txt = FALSE, rowids = TRUE)
+            )
+            expect_equal(
+              percMethylation(methylBase.obj, save.txt = FALSE, rowids = FALSE),
+              percMethylation(methylBaseDB, save.txt = FALSE, rowids = FALSE)
+            )
+          })
+
+## save txt
+test_that("check if percMethylation is writting to file for methylBaseDB",
+          {
+            expect_equal(
+              as.matrix(read.delim(
+                percMethylation(methylBaseDB, save.txt = TRUE, rowids = TRUE),
+                header = TRUE,
+                row.names = 1
+              )),
+              percMethylation(methylBase.obj, save.txt = TRUE, rowids = TRUE)
+            )
+            
+            expect_equal(
+              as.matrix(read.delim(
+                percMethylation(methylBaseDB, save.txt = TRUE, rowids = FALSE),
+                header = TRUE
+              )),
+              percMethylation(methylBase.obj, save.txt = TRUE, rowids = FALSE)
+            )
+          })
+
+
+unlink(dbdir, recursive = TRUE)


### PR DESCRIPTION
Allow optional writing of colnames and rownames if returntype is text. Find details in https://github.com/al2na/methylKit/issues/169.

- Fixes https://github.com/al2na/methylKit/issues/169
- Fixes https://github.com/al2na/methylKit/issues/170