### PR TITLE
Fix bedgraph error due to NA handling in meth.diff export

### DIFF
--- a/R/bedgraph.R
+++ b/R/bedgraph.R
@@ -91,6 +91,9 @@ setMethod("bedgraph", signature(methylObj="methylDiff"),
   {
     stop("col.name argument is not one of 'pvalue','qvalue', 'meth.diff'")
   }
+  if (col.name == "meth.diff" && log.transform) {
+    stop("Log transformation is not allowed for 'meth.diff' values")
+  }
   mdata=getData(methylObj)
   df=data.frame(chr=mdata$chr,
                 start=mdata$start-1,
@@ -188,7 +191,7 @@ setMethod("bedgraph", signature(methylObj="methylRaw"),
     options(scipen = defsci)
   }
    
-                        
+                         
 }
 
 )
@@ -308,4 +311,3 @@ setMethod("bedgraph", signature(methylObj="methylRawList"),
       options(scipen = defsci)
   }
 })
- 

--- a/R/methylDBFunctions.R
+++ b/R/methylDBFunctions.R
@@ -417,7 +417,7 @@ setMethod("adjustMethylC", c("methylRawDB","methylRawDB"),
     
   }
   
-  
+   
 })
 
 
@@ -1083,7 +1083,7 @@ setMethod("percMethylation", "methylBaseDB",
                    chunk.size = 1e6) {
             meth.fun <- function(data, numCs.index, numTs.index, rowids) {
               dat = 100 * data[, numCs.index] / (data[, numCs.index] +
-                                                   data[, numTs.index])
+                                                 data[, numTs.index])
               if(rowids) {
                 dat = cbind(pos = 
                               paste(as.character(data[, 1]),
@@ -2631,6 +2631,9 @@ setMethod("bedgraph", signature(methylObj="methylDiffDB"),
   if(! col.name %in% c('pvalue','qvalue', 'meth.diff') )
   {
     stop("col.name argument is not one of 'pvalue','qvalue', 'meth.diff'")
+  }
+  if (col.name == "meth.diff" && log.transform) {
+    stop("Log transformation is not allowed for 'meth.diff' values")
   }
   
   bedgr <- function(data,col.name,file.name,log.transform,negative,add.on,

--- a/tests/testthat/test-17-bedgraph.r
+++ b/tests/testthat/test-17-bedgraph.r
@@ -14,15 +14,13 @@ bedgraph(methylDiff.obj, file.name=outFile, col.name="meth.diff",
         unmeth=FALSE,log.transform=FALSE,negative=FALSE,add.on="")
 tt <- rtracklayer::import.bedGraph(outFile)
 outFile2 <- tempfile(pattern = "mdiff.",tmpdir = outDir,fileext = ".bed")
-suppressWarnings(bedgraph(methylDiff.obj,col.name = "meth.diff",
-         log.transform = TRUE,negative = TRUE,file.name = outFile2))
-tt2 <- rtracklayer::import.bedGraph(outFile2)
 
 
 test_that("export methylDiff worked", {
   expect_true(file.exists(outFile))
   expect_equal(length(tt),nrow(methylDiff.obj))
-  expect_equal(length(tt2),nrow(methylDiff.obj))
+  expect_error(bedgraph(methylDiff.obj,col.name = "meth.diff",
+         log.transform = TRUE,negative = TRUE,file.name = outFile2))
   expect_is(bedgraph(methylDiff.obj,col.name = "meth.diff"),
             class = "data.frame")
   expect_error(bedgraph(methylDiff.obj,col.name = "coverage"))
@@ -51,8 +49,6 @@ test_that("export methylRaw worked", {
   expect_error(bedgraph(methylRawList.obj[[1]],col.name = "meth.diff"))
 })
 
-
-
 # getting a bedgraph file from a methylRawList object containing raw
 #methylation values
 outFile <- tempfile(pattern = "mRawL",tmpdir = outDir,fileext = ".bed")
@@ -74,6 +70,24 @@ test_that("export methylRaw worked", {
   expect_error(bedgraph(methylRawList.obj,col.name = "meth.diff"))
 })
 
+# getting a bedgraph file from a methylDiffDB object containing differential
+# methylation percentages
+outFile <- tempfile(pattern = "mdiffDB.",tmpdir = outDir,fileext = ".bed")
+methylDiffDB.obj <- makeMethylDB(methylDiff.obj, dbdir)
+bedgraph(methylDiffDB.obj, file.name=outFile, col.name="meth.diff",
+        unmeth=FALSE,log.transform=FALSE,negative=FALSE,add.on="")
+tt <- rtracklayer::import.bedGraph(outFile)
+outFile2 <- tempfile(pattern = "mdiffDB.",tmpdir = outDir,fileext = ".bed")
+
+test_that("export methylDiffDB worked", {
+  expect_true(file.exists(outFile))
+  expect_equal(length(tt),methylDiffDB.obj@num.records)
+  expect_error(bedgraph(methylDiffDB.obj,col.name = "meth.diff",
+         log.transform = TRUE,negative = TRUE,file.name = outFile2))
+  expect_is(bedgraph(methylDiffDB.obj,col.name = "meth.diff"),
+            class = "data.frame")
+  expect_error(bedgraph(methylDiffDB.obj,col.name = "coverage"))
+})
 
 # remove the file
 unlink(outDir,recursive = TRUE)


### PR DESCRIPTION
Fixes #331

Fix the error in `tests/testthat/test-17-bedgraph.r` due to NA handling in `meth.diff` export as log-transformed value.

* **R/bedgraph.R**
  - Disallow transformation of `meth.diff` values in `bedgraph` function for `methylDiff` objects.
  - Add a check to ensure `log.transform` is `FALSE` when `col.name` is `meth.diff`.

* **tests/testthat/test-17-bedgraph.r**
  - Update tests to ensure `log.transform` is not allowed for `meth.diff` values.
  - Add a test to check for error when `log.transform` is `TRUE` for `meth.diff`.
  - Add tests for `methylDiffDB` objects to ensure `log.transform` is not allowed for `meth.diff` values.

* **R/methylDBFunctions.R**
  - Add a check to ensure `log.transform` is `FALSE` when `col.name` is `meth.diff`.
  - Disallow transformation of `meth.diff` values in `bedgraph` function for `methylDiffDB` objects.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/al2na/methylKit/pull/332?shareId=b0f6436a-bac7-4fd5-ae7c-40d68069a7de).